### PR TITLE
Implement QUnit.test, QUnit.asyncTest and QUnit.ok

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -104,8 +104,11 @@ module.exports = function(grunt) {
 
 ## Running tests
 
-Just run `npm test` from the project directory. You can run QUnit's test suite
-by opening `test/qunit.html` in a browser.
+1. Install dependencies: `npm install`
+2. Update QUnit submodule `git submodule update --init --recursive`
+3. `npm test`
+
+You can run QUnit's test suite by opening `test/qunit.html` in a browser.
 
 ## License
 

--- a/mocha-qunit-ui.js
+++ b/mocha-qunit-ui.js
@@ -2560,6 +2560,7 @@ var ui = function(suite) {
       });
     });
     global.ok = assert.ok;
+    QUnit.ok = assert.ok;
   };
 
   suite.on('pre-require', function(context) {
@@ -2751,11 +2752,11 @@ var ui = function(suite) {
      * with the given `title`, an optional number of assertions to expect,
      * callback `test` acting as a thunk.
      */
-    context.test = normalizeTestArgs(function(title, expect, test) {
+    context.test = QUnit.test = normalizeTestArgs(function(title, expect, test) {
       addTest(title, expect, test);
     });
 
-    context.asyncTest = normalizeTestArgs(function(title, expect, test) {
+    context.asyncTest = QUnit.asyncTest = normalizeTestArgs(function(title, expect, test) {
       addTest(title, expect, wrapTestFunction(test, function(test, done) {
         context.stop();
         test.call(this, assert);

--- a/package.json
+++ b/package.json
@@ -9,10 +9,10 @@
   },
   "devDependencies": {
     "grunt": "~0.4.2",
-    "grunt-mocha": "~0.4.6",
     "grunt-contrib-concat": "~0.3.0",
+    "grunt-mocha": "~0.4.6",
     "grunt-mocha-test": "~0.8.0",
-    "mocha": "~2.0.1"
+    "mocha": "^3.2.0"
   },
   "main": "mocha-qunit-ui.js",
   "scripts": {

--- a/src/mocha-qunit-ui.js
+++ b/src/mocha-qunit-ui.js
@@ -172,6 +172,7 @@ var ui = function(suite) {
       });
     });
     global.ok = assert.ok;
+    QUnit.ok = assert.ok;
   };
 
   suite.on('pre-require', function(context) {
@@ -363,11 +364,11 @@ var ui = function(suite) {
      * with the given `title`, an optional number of assertions to expect,
      * callback `test` acting as a thunk.
      */
-    context.test = normalizeTestArgs(function(title, expect, test) {
+    context.test = QUnit.test = normalizeTestArgs(function(title, expect, test) {
       addTest(title, expect, test);
     });
 
-    context.asyncTest = normalizeTestArgs(function(title, expect, test) {
+    context.asyncTest = QUnit.asyncTest = normalizeTestArgs(function(title, expect, test) {
       addTest(title, expect, wrapTestFunction(test, function(test, done) {
         context.stop();
         test.call(this, assert);

--- a/test/expected-failures/qunit-namespace.js
+++ b/test/expected-failures/qunit-namespace.js
@@ -1,0 +1,15 @@
+QUnit.test('false', function(assert) {
+  assert.ok(false);
+});
+QUnit.test('0', function(assert) {
+  assert.ok(0);
+});
+QUnit.test('""', function(assert) {
+  assert.ok('');
+});
+QUnit.test('undefined', function(assert) {
+  assert.ok(undefined);
+});
+QUnit.test('null', function(assert) {
+  assert.ok(null);
+});


### PR DESCRIPTION
Currently `mocha-qunit-ui` namespaces only `module` due to the conflict with Node, so it becomes `QUnit.module`.

This PR also overloads `QUnit.test` and `QUnit.asyncTest`. I am in the process of trying to get some existing QUnit test suites running in Node, and they all use `QUnit.test` to reduce the reliance on globals.

One interesting thing about this PR is that it actually caught a bug! There is exactly *one* test in `qunit/test/test.js` that uses `QUnit.test` instead of the global `test`, for who knows what reason. That test was being lost because it was not shimmed by `mocha-qunit-ui`. Once I shimmed `QUnit.test`, it started working, but was failing because it _also_ relied on `QUnit.ok`. So I've added a spy on to `QUnit.ok` here as well, just to get that one test passing.

I also went ahead and upgraded the version of mocha used for testing. It didn't require any changes but it seemed good to upgrade.